### PR TITLE
Add activity-scoped layout tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Optional active-layout tracking per KDE Activity.
+
 ## [0.2.3] - 2026-05-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Optional active-layout tracking per KDE Activity.
+- Activity-scoped window placement restore for existing windows when activity
+  layout tracking is enabled.
 
 ## [0.2.3] - 2026-05-09
 

--- a/PROJECT_DESIGN.md
+++ b/PROJECT_DESIGN.md
@@ -139,6 +139,14 @@ when `trackLayoutPerDesktop` is also enabled. When
 `trackLayoutPerActivity` is enabled, the active KDE Activity id is also part of
 the runtime layout key, so each activity can remember its own active layout.
 
+When activity layout tracking is enabled, each client also keeps an in-memory
+`magnetileActivityPlacements` map keyed by output, virtual desktop, and KDE
+Activity id. Magnetile updates that map when it tiles, frees, resets, or
+connected-resizes a window. On `Workspace.currentActivityChanged`, visible
+windows belonging to the new activity are restored from the matching placement
+entry. This is intentionally runtime state only; Magnetile does not launch apps
+or persist activity placements across KWin restarts.
+
 Monitor identity uses KWin output names (`output.name`). Geometry does not rely
 on output order or an origin of `x=0, y=0`; snapping uses
 `Workspace.clientArea(KWin.FullScreenArea, output, desktop)` plus percentage

--- a/PROJECT_DESIGN.md
+++ b/PROJECT_DESIGN.md
@@ -135,7 +135,9 @@ defaults. If no valid mapping exists, landscape outputs prefer `Priority Grid`
 and portrait outputs prefer `Horizontal Split` when those layouts exist. After
 seeding, runtime layout switching is tracked
 independently in memory for that output, and optionally for that virtual desktop
-when `trackLayoutPerDesktop` is also enabled.
+when `trackLayoutPerDesktop` is also enabled. When
+`trackLayoutPerActivity` is enabled, the active KDE Activity id is also part of
+the runtime layout key, so each activity can remember its own active layout.
 
 Monitor identity uses KWin output names (`output.name`). Geometry does not rely
 on output order or an origin of `x=0, y=0`; snapping uses

--- a/README.md
+++ b/README.md
@@ -575,9 +575,11 @@ zone rules.
 #### Activity Layout Tracking
 
 Enable **Track active layout per activity** to remember the selected layout
-separately for each KDE Activity. This only scopes the active layout selection;
-shared windows still keep a single Magnetile zone assignment until
-activity-scoped window placement is added.
+separately for each KDE Activity. Existing windows can also keep separate
+runtime placements per activity after they are moved or resized in each
+activity. Magnetile restores those remembered placements when switching
+activities, but it does not launch activity-specific apps or persist this
+runtime placement state across KWin restarts.
 
 ## Shortcuts
 

--- a/README.md
+++ b/README.md
@@ -572,6 +572,13 @@ Enable script logging or show the runtime debug overlay. The debug overlay is
 useful for finding a window's resource class for filters or application-based
 zone rules.
 
+#### Activity Layout Tracking
+
+Enable **Track active layout per activity** to remember the selected layout
+separately for each KDE Activity. This only scopes the active layout selection;
+shared windows still keep a single Magnetile zone assignment until
+activity-scoped window placement is added.
+
 ## Shortcuts
 
 List of all available shortcuts:

--- a/src/contents/code/core.mjs
+++ b/src/contents/code/core.mjs
@@ -76,6 +76,7 @@ export function loadConfig() {
   config.trackLayoutPerScreen = KWin.readConfig("trackLayoutPerScreen", false);
   config.monitorLayouts = monitorLayouts;
   config.trackLayoutPerDesktop = KWin.readConfig("trackLayoutPerDesktop", false);
+  config.trackLayoutPerActivity = KWin.readConfig("trackLayoutPerActivity", false);
   config.showOsdMessages = KWin.readConfig("showOsdMessages", true);
   config.fadeWindowsWhileMoving = KWin.readConfig("fadeWindowsWhileMoving", false);
   config.autoSnapAllNew = KWin.readConfig("autoSnapAllNew", false);

--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -54,6 +54,10 @@
             <default>false</default>
         </entry>
 
+        <entry name="trackLayoutPerActivity" type="Bool">
+            <default>false</default>
+        </entry>
+
         <entry name="autoSnapAllNew" type="Bool">
             <default>false</default>
         </entry>

--- a/src/contents/ui/config.ui
+++ b/src/contents/ui/config.ui
@@ -337,6 +337,13 @@
                       </widget>
                     </item>
                     <item>
+                      <widget class="QCheckBox" name="kcfg_trackLayoutPerActivity">
+                        <property name="text">
+                          <string>Track active layout per activity</string>
+                        </property>
+                      </widget>
+                    </item>
+                    <item>
                       <widget class="QCheckBox" name="kcfg_autoSnapAllNew">
                         <property name="text">
                           <string>Automatically snap all new windows</string>

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -240,6 +240,7 @@ Item {
             "resizing": resizing,
             "oldGeometry": Workspace.activeWindow && Workspace.activeWindow.oldGeometry,
             "activeScreen": activeScreen && activeScreen.name,
+            "currentActivity": Workspace.currentActivity,
             "currentLayout": currentLayout,
             "screenLayouts": screenLayouts,
             "resize": resizeDebugInfo
@@ -1681,11 +1682,14 @@ Item {
         if (config.trackLayoutPerDesktop)
             parts.push(Workspace.currentDesktop.id);
 
+        if (config.trackLayoutPerActivity)
+            parts.push(Workspace.currentActivity || "");
+
         return parts.join(':');
     }
 
     function getCurrentLayout() {
-        if (config.trackLayoutPerScreen || config.trackLayoutPerDesktop) {
+        if (config.trackLayoutPerScreen || config.trackLayoutPerDesktop || config.trackLayoutPerActivity) {
             const key = getLayoutKey();
             if (screenLayouts[key] === undefined)
                 screenLayouts[key] = config.trackLayoutPerScreen ? configuredLayoutForOutput(activeScreen || Workspace.activeScreen) : 0;
@@ -1696,7 +1700,7 @@ Item {
     }
 
     function setCurrentLayout(layout) {
-        if (config.trackLayoutPerScreen || config.trackLayoutPerDesktop)
+        if (config.trackLayoutPerScreen || config.trackLayoutPerDesktop || config.trackLayoutPerActivity)
             screenLayouts[getLayoutKey()] = clampLayoutIndex(layout);
 
         currentLayout = clampLayoutIndex(layout);
@@ -1710,6 +1714,9 @@ Item {
 
         if (config.trackLayoutPerDesktop)
             parts.push(Workspace.currentDesktop.name);
+
+        if (config.trackLayoutPerActivity)
+            parts.push(Workspace.currentActivity || "activity");
 
         if (parts.length > 0)
             return `${name} (${parts.join(' / ')})`;
@@ -2884,6 +2891,15 @@ Item {
                 return;
 
             if (config.trackLayoutPerDesktop)
+                currentLayout = getCurrentLayout();
+
+        }
+
+        function onCurrentActivityChanged() {
+            if (disposing)
+                return;
+
+            if (config.trackLayoutPerActivity)
                 currentLayout = getCurrentLayout();
 
         }

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -188,6 +188,21 @@ Item {
         return client && client.activity !== undefined ? client.activity : Workspace.currentActivity;
     }
 
+    function clientActivities(client) {
+        if (client && client.activities !== undefined)
+            return client.activities;
+
+        return [];
+    }
+
+    function clientOnActivity(client, activity) {
+        const activities = clientActivities(client);
+        if (!activity || !isArrayValue(activities) || activities.length === 0)
+            return true;
+
+        return activities.indexOf(activity) !== -1;
+    }
+
     function clientDebugName(client) {
         if (!client)
             return "<none>";
@@ -271,7 +286,118 @@ Item {
     }
 
     function clientInCurrentScope(client, output, desktop, activity) {
-        return clientOutput(client) === output && sameDesktop(client, desktop) && clientActivity(client) === activity;
+        return clientOutput(client) === output && sameDesktop(client, desktop) &&
+            (config.trackLayoutPerActivity ? clientOnActivity(client, activity) : clientActivity(client) === activity);
+    }
+
+    function placementScopeKey(client, screen, desktop, activity) {
+        const resolvedScreen = screen || clientOutput(client);
+        const resolvedDesktop = desktop || Workspace.currentDesktop;
+        const parts = [
+            outputName(resolvedScreen),
+            resolvedDesktop && resolvedDesktop.id ? resolvedDesktop.id : "",
+            activity !== undefined && activity !== null ? activity : ""
+        ];
+        return parts.join(":");
+    }
+
+    function scopedClientPlacements(client) {
+        if (!client)
+            return {};
+
+        const placements = client.magnetileActivityPlacements;
+        if (placements && !isArrayValue(placements) && typeof placements === "object")
+            return placements;
+
+        return {};
+    }
+
+    function saveScopedClientPlacement(client) {
+        if (!config.trackLayoutPerActivity || !client)
+            return;
+
+        const key = placementScopeKey(client, clientOutput(client), Workspace.currentDesktop, Workspace.currentActivity);
+        const placements = scopedClientPlacements(client);
+        const layout = validLayoutIndex(client.layout) ? clampLayoutIndex(client.layout) : currentLayout;
+        placements[key] = {
+            "zone": validZoneIndex(layout, client.zone) ? Math.round(Number(client.zone)) : -1,
+            "zones": normalizeZoneList(layout, client.zones),
+            "layout": layout,
+            "mergedZone": client.magnetileMergedZone || "",
+            "resetZone": validZoneIndex(layout, client.magnetileResetZone) ? Math.round(Number(client.magnetileResetZone)) : -1,
+            "freeMove": client.magnetileFreeMove === true,
+            "tiled": client.magnetileTiled === true,
+            "geometry": {
+                "x": client.frameGeometry.x,
+                "y": client.frameGeometry.y,
+                "width": client.frameGeometry.width,
+                "height": client.frameGeometry.height
+            }
+        };
+        client.magnetileActivityPlacements = Object.assign({}, placements);
+    }
+
+    function restoreScopedClientPlacement(client, activity) {
+        if (!config.trackLayoutPerActivity || !client || !canMutateWindowGeometry(client))
+            return false;
+
+        if (!clientOnActivity(client, activity) || !sameDesktop(client, Workspace.currentDesktop))
+            return false;
+
+        const key = placementScopeKey(client, clientOutput(client), Workspace.currentDesktop, activity);
+        const placement = scopedClientPlacements(client)[key];
+        if (!placement || !validLayoutIndex(placement.layout))
+            return false;
+
+        const layout = clampLayoutIndex(placement.layout);
+        const zones = normalizeZoneList(layout, placement.zones !== undefined ? placement.zones : placement.zone);
+        const zone = zones.length > 0 ? zones[0] : (validZoneIndex(layout, placement.zone) ? Math.round(Number(placement.zone)) : -1);
+        let geometry = null;
+
+        if (placement.freeMove) {
+            geometry = rectFromStoredGeometry(placement.geometry);
+        } else if (zones.length > 1) {
+            geometry = resizeLogicalGeometry(layout, zones, clientOutput(client));
+        } else if (validZoneIndex(layout, zone)) {
+            geometry = targetGeometry(effectiveTargetForZone(layout, zone, clientOutput(client), Workspace.currentDesktop, activity));
+        }
+
+        if (!geometry)
+            return false;
+
+        client.layout = layout;
+        client.zone = zone;
+        client.zones = zones.length > 0 ? zones : (validZoneIndex(layout, zone) ? [zone] : []);
+        client.magnetileMergedZone = placement.mergedZone || (zones.length > 1 ? mergeIdForZones(zones) : "");
+        client.magnetileResetZone = validZoneIndex(layout, placement.resetZone) ? Math.round(Number(placement.resetZone)) : -1;
+        client.desktop = Workspace.currentDesktop;
+        client.activity = activity;
+        client.magnetileFreeMove = placement.freeMove === true;
+        client.magnetileTiled = placement.tiled === true && !placement.freeMove;
+        client.magnetileResizeSnapshot = null;
+
+        if (!rectsClose(client.frameGeometry, geometry)) {
+            client.setMaximize(false, false);
+            client.frameGeometry = geometry;
+        }
+        return true;
+    }
+
+    function restoreScopedPlacementsForActivity(activity) {
+        if (!config.trackLayoutPerActivity)
+            return 0;
+
+        let count = 0;
+        for (let i = 0; i < Workspace.stackingOrder.length; i++) {
+            const client = Workspace.stackingOrder[i];
+            if (!checkFilter(client) || client.minimized)
+                continue;
+
+            if (restoreScopedClientPlacement(client, activity))
+                count++;
+        }
+        Utils.log("Restored " + count + " activity-scoped placements for " + (activity || "<activity>"));
+        return count;
     }
 
     function recoverClientZone(client, layout, fallbackToClosest) {
@@ -1090,6 +1216,7 @@ Item {
             client.magnetileTiled = true;
             client.magnetileResizeSnapshot = null;
             clearClientTargetProperties(client);
+            saveScopedClientPlacement(client);
             count++;
         }
 
@@ -1352,6 +1479,7 @@ Item {
         client.magnetileFreeMove = false;
         client.setMaximize(false, false);
         client.frameGeometry = geometry;
+        saveScopedClientPlacement(client);
     }
 
     function freeClient(client) {
@@ -1366,6 +1494,7 @@ Item {
         client.magnetileTiled = false;
         client.magnetileResizeSnapshot = null;
         clearClientTargetProperties(client);
+        saveScopedClientPlacement(client);
     }
 
     function toggleFreeClient(client) {
@@ -1409,6 +1538,8 @@ Item {
             client.zones = [zone];
             client.magnetileMergedZone = "";
         }
+        if (zone === -1)
+            saveScopedClientPlacement(client);
     }
 
     function saveClientTargetProperties(client, target) {
@@ -1457,6 +1588,7 @@ Item {
             client.setMaximize(false, false);
             client.frameGeometry = geometry;
             client.magnetileResizeSnapshot = null;
+            saveScopedClientPlacement(client);
         }
     }
 
@@ -2181,6 +2313,10 @@ Item {
 
         restoreResizeTargetProperties(client, snapshot, snapshot);
         updateRuntimeLayoutGeometry(snapshot, client.frameGeometry);
+        saveScopedClientPlacement(client);
+        for (let i = 0; i < snapshot.windows.length; i++)
+            saveScopedClientPlacement(snapshot.windows[i].client);
+
         resizeDebugInfo.lastApplied = applied;
         resizeDebugInfo = Object.assign({}, resizeDebugInfo);
         return applied;
@@ -2901,6 +3037,8 @@ Item {
 
             if (config.trackLayoutPerActivity)
                 currentLayout = getCurrentLayout();
+
+            restoreScopedPlacementsForActivity(Workspace.currentActivity);
 
         }
 


### PR DESCRIPTION
## Summary

- Adds a disabled-by-default `trackLayoutPerActivity` setting.
- Includes the active KDE Activity id in the active-layout key when enabled.
- Restores existing windows to activity-scoped runtime placements when switching activities.
- Updates OSD/debug context and docs for the new scope.

This is the implementation path for #10. It intentionally does not launch activity-specific apps; it only restores placement for windows that already exist and belong to the current activity.

## Validation

- `make build`
- `xmllint --noout src/contents/config/main.xml src/contents/ui/config.ui`
- Local KWin restart/load confirmed `trackLayoutPerActivity:true` in script config logs.

## Manual test plan

1. Load this branch locally.
2. Enable **Track active layout per activity** in Magnetile settings.
3. On Activity A, activate layout 1 and move a shared test window to zone 1.
4. Switch to Activity B, activate layout 2 and move the same shared test window to a different zone.
5. Switch back to Activity A and verify the window returns to Activity A's saved placement.
6. Switch back to Activity B and verify the window returns to Activity B's saved placement.
7. Repeat with a non-shared window to confirm windows outside the active activity are not moved unexpectedly.

## Revertability

This branch is split into focused commits:

- `5b75a5e` adds activity-scoped active layout selection.
- `7ec8398` adds activity-scoped runtime window placement restore.

If window placement behavior misbehaves, revert `7ec8398` first and keep the simpler layout-selection slice. If the whole feature needs to be backed out, revert both commits or close/delete this branch without touching `main`.

Closes #10 after manual testing confirms the shared-window placement behavior.
