### PR TITLE
Add manual activity launcher profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional active-layout tracking per KDE Activity.
 - Activity-scoped window placement restore for existing windows when activity
   layout tracking is enabled.
-- Activity launcher profiles with a manual shortcut that opens KRunner for
-  missing profile apps and snaps matching windows when they appear.
+- Activity launcher profiles with a manual shortcut that opens missing profile
+  apps from desktop entries and snaps matching windows when they appear.
 
 ## [0.2.3] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional active-layout tracking per KDE Activity.
 - Activity-scoped window placement restore for existing windows when activity
   layout tracking is enabled.
+- Activity launcher profiles with a manual shortcut that opens KRunner for
+  missing profile apps and snaps matching windows when they appear.
 
 ## [0.2.3] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-23
+
 ### Added
 
 - Optional active-layout tracking per KDE Activity.
 - Activity-scoped window placement restore for existing windows when activity
   layout tracking is enabled.
-- Activity launcher profiles with a manual shortcut that opens missing profile
-  apps from desktop entries and snaps matching windows when they appear.
+- Activity placement profiles that snap newly opened matching windows to
+  configured zones for the current KDE Activity.
+
+### Changed
+
+- Activity profiles no longer launch applications from inside the KWin script.
+  Use KDE application shortcuts, launchers, or an external helper to start apps;
+  Magnetile handles detection and placement when the windows appear.
+
+### Fixed
+
+- Activity-scoped placement restore now uses the window's actual KWin output
+  instead of falling back to the active output during activity switches.
 
 ## [0.2.3] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,22 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Optional active-layout tracking per KDE Activity.
-- Activity-scoped window placement restore for existing windows when activity
-  layout tracking is enabled.
-- Activity placement profiles that snap newly opened matching windows to
-  configured zones for the current KDE Activity.
+- Optional active-layout tracking per KDE Activity, so each Activity can keep
+  its own active layout per monitor.
+- Activity-scoped placement memory for existing windows, so windows can return
+  to their Activity-specific Magnetile zone when switching Activities.
+- Optional Activity placement profiles that snap newly opened matching windows
+  to configured zones for the current KDE Activity.
 
 ### Changed
 
-- Activity profiles no longer launch applications from inside the KWin script.
-  Use KDE application shortcuts, launchers, or an external helper to start apps;
-  Magnetile handles detection and placement when the windows appear.
-
-### Fixed
-
-- Activity-scoped placement restore now uses the window's actual KWin output
-  instead of falling back to the active output during activity switches.
+- Activity profiles are placement-only. Magnetile does not launch applications
+  from inside the KWin script; use KDE application shortcuts, launchers, or an
+  external helper to start apps.
 
 ## [0.2.3] - 2026-05-09
 

--- a/PROJECT_DESIGN.md
+++ b/PROJECT_DESIGN.md
@@ -147,15 +147,12 @@ windows belonging to the new activity are restored from the matching placement
 entry. This is intentionally runtime state only; Magnetile does not launch apps
 or persist activity placements across KWin restarts.
 
-Activity launcher profiles are stored separately in `activityProfilesJson`.
+Activity placement profiles are stored separately in `activityProfilesJson`.
 Profiles are keyed by KDE Activity id and can list apps by display name,
-desktop entry id, window class, and one-based target zone. `desktopEntry` uses
-the launcher id form accepted by `applications:` URLs, normally the desktop file
-basename without `.desktop`. The initial launcher implementation does not
-execute arbitrary shell commands from KWin. Instead, the manual profile shortcut
-opens the first configured app through Qt's external URL launcher using an
-`applications:` URL, and the normal `windowAdded` path snaps matching windows
-to their profile zones when they appear.
+desktop entry id, window class, and one-based target zone. The KWin script does
+not launch apps directly; app startup is delegated to KDE application shortcuts,
+launchers, or a future external helper. The normal `windowAdded` path snaps
+matching windows to their profile zones when they appear.
 
 Monitor identity uses KWin output names (`output.name`). Geometry does not rely
 on output order or an origin of `x=0, y=0`; snapping uses

--- a/PROJECT_DESIGN.md
+++ b/PROJECT_DESIGN.md
@@ -149,11 +149,13 @@ or persist activity placements across KWin restarts.
 
 Activity launcher profiles are stored separately in `activityProfilesJson`.
 Profiles are keyed by KDE Activity id and can list apps by display name,
-desktop entry id, window class, and one-based target zone. The initial launcher
-implementation does not execute arbitrary shell commands from KWin. Instead,
-the manual profile shortcut opens the first missing app through Qt's external
-URL launcher using an `applications:` URL, and the normal `windowAdded` path
-snaps matching windows to their profile zones when they appear.
+desktop entry id, window class, and one-based target zone. `desktopEntry` uses
+the launcher id form accepted by `applications:` URLs, normally the desktop file
+basename without `.desktop`. The initial launcher implementation does not
+execute arbitrary shell commands from KWin. Instead, the manual profile shortcut
+opens the first configured app through Qt's external URL launcher using an
+`applications:` URL, and the normal `windowAdded` path snaps matching windows
+to their profile zones when they appear.
 
 Monitor identity uses KWin output names (`output.name`). Geometry does not rely
 on output order or an origin of `x=0, y=0`; snapping uses

--- a/PROJECT_DESIGN.md
+++ b/PROJECT_DESIGN.md
@@ -147,6 +147,15 @@ windows belonging to the new activity are restored from the matching placement
 entry. This is intentionally runtime state only; Magnetile does not launch apps
 or persist activity placements across KWin restarts.
 
+Activity launcher profiles are stored separately in `activityProfilesJson`.
+Profiles are keyed by KDE Activity id and can list apps by display name,
+KRunner query/command, window class, and one-based target zone. The initial
+launcher implementation does not silently execute arbitrary commands from KWin.
+Instead, the manual profile shortcut opens KRunner for the first missing app,
+and the normal `windowAdded` path snaps matching windows to their profile zones
+when they appear. This keeps app spawning user-visible until a reliable
+auto-launch backend is available.
+
 Monitor identity uses KWin output names (`output.name`). Geometry does not rely
 on output order or an origin of `x=0, y=0`; snapping uses
 `Workspace.clientArea(KWin.FullScreenArea, output, desktop)` plus percentage

--- a/PROJECT_DESIGN.md
+++ b/PROJECT_DESIGN.md
@@ -149,12 +149,11 @@ or persist activity placements across KWin restarts.
 
 Activity launcher profiles are stored separately in `activityProfilesJson`.
 Profiles are keyed by KDE Activity id and can list apps by display name,
-KRunner query/command, window class, and one-based target zone. The initial
-launcher implementation does not silently execute arbitrary commands from KWin.
-Instead, the manual profile shortcut opens KRunner for the first missing app,
-and the normal `windowAdded` path snaps matching windows to their profile zones
-when they appear. This keeps app spawning user-visible until a reliable
-auto-launch backend is available.
+desktop entry id, window class, and one-based target zone. The initial launcher
+implementation does not execute arbitrary shell commands from KWin. Instead,
+the manual profile shortcut opens the first missing app through Qt's external
+URL launcher using an `applications:` URL, and the normal `windowAdded` path
+snaps matching windows to their profile zones when they appear.
 
 Monitor identity uses KWin output names (`output.name`). Geometry does not rely
 on output order or an origin of `x=0, y=0`; snapping uses

--- a/README.md
+++ b/README.md
@@ -583,11 +583,10 @@ runtime placement state across KWin restarts.
 
 #### Activity Launcher Profiles
 
-Activity profiles can list apps that belong to a KDE Activity. The first
-launcher implementation is intentionally user-visible: assign a shortcut to
-**Magnetile: Launch current activity profile**, and Magnetile opens KRunner for
-the first missing app in the current profile. When a matching window appears,
-Magnetile snaps it to the configured zone.
+Activity profiles can list apps that belong to a KDE Activity. Assign a
+shortcut to **Magnetile: Launch current activity profile**, and Magnetile opens
+the first missing app in the current profile from its desktop entry. When a
+matching window appears, Magnetile snaps it to the configured zone.
 
 Profiles are keyed by KDE Activity id:
 
@@ -599,7 +598,7 @@ Profiles are keyed by KDE Activity id:
       "apps": [
         {
           "name": "Browser",
-          "command": "firefox",
+          "desktopEntry": "firefox.desktop",
           "class": "firefox",
           "zone": 1
         }
@@ -609,11 +608,11 @@ Profiles are keyed by KDE Activity id:
 }
 ```
 
-`zone` is one-based for readability. `command` is sent to KRunner; `class`
-is the KWin window class used to detect existing windows and snap newly opened
-windows. `launchMode: "prompt"` shows an OSD reminder when switching to an
-activity with missing apps. Silent automatic launch is intentionally not enabled
-until Magnetile has a reliable Plasma 6 launch backend.
+`zone` is one-based for readability. `desktopEntry` is opened through the
+system application launcher; `class` is the KWin window class used to detect
+existing windows and snap newly opened windows. `launchMode: "prompt"` shows an
+OSD reminder when switching to an activity with missing apps. Silent automatic
+launch is intentionally not enabled yet.
 
 ## Shortcuts
 

--- a/README.md
+++ b/README.md
@@ -23,15 +23,17 @@ The editor can import your current Magnetile layout JSON, edit zones visually,
 configure custom edge-snap triggers, and export JSON for Magnetile, KZones, or
 PlasmaZones.
 
-## What's New In 0.2.0
+## What's New In 0.3.0
 
-Magnetile 0.2.0 adds runtime merged zones. While dragging a window, drop near
-the shared edge between adjacent zones to snap across both zones instead of
-choosing only one. Magnetile highlights the larger merged target before release,
-then keeps the merged area active until the layout is reset with `Ctrl+Alt+R`.
+Magnetile 0.3.0 adds KDE Activity-aware layouts. If you enable activity
+tracking, each Activity can keep its own active layout on each monitor, so a
+work Activity can use a different layout than a gaming, writing, or homelab
+Activity without manually switching layouts every time.
 
-Existing tiled windows in the affected zones expand to the same merged target,
-so a newly merged area does not leave older windows hidden underneath.
+Existing windows can also keep separate Magnetile placements per Activity while
+KWin moves them in and out of view. This makes Activity switching behave more
+like switching between complete workspace setups instead of only changing which
+windows are visible.
 
 Development of the Magnetile-specific changes is AI-assisted. Human review,
 testing, packaging, and licensing responsibility remain with the Magnetile

--- a/README.md
+++ b/README.md
@@ -581,12 +581,12 @@ activity. Magnetile restores those remembered placements when switching
 activities, but it does not launch activity-specific apps or persist this
 runtime placement state across KWin restarts.
 
-#### Activity Launcher Profiles
+#### Activity Placement Profiles
 
-Activity profiles can list apps that belong to a KDE Activity. Assign a
-shortcut to **Magnetile: Launch current activity profile**, and Magnetile opens
-the first missing app in the current profile from its desktop entry. When a
-matching window appears, Magnetile snaps it to the configured zone.
+Activity profiles can list apps that belong to a KDE Activity. Magnetile does
+not launch those apps from inside KWin; use KDE application shortcuts, launchers,
+or an external helper to start them. When a matching window appears, Magnetile
+snaps it to the configured zone.
 
 Profiles are keyed by KDE Activity id:
 
@@ -608,12 +608,11 @@ Profiles are keyed by KDE Activity id:
 }
 ```
 
-`zone` is one-based for readability. `desktopEntry` is the application id used
-by the system launcher, usually the desktop file basename without `.desktop`
-such as `firefox` or `org.kde.kate`; `class` is the KWin window class used to
-detect existing windows and snap newly opened windows. `launchMode: "prompt"`
-shows an OSD reminder when switching to an activity with missing apps. Silent
-automatic launch is intentionally not enabled yet.
+`zone` is one-based for readability. `class` is the KWin window class used to
+detect existing windows and snap newly opened windows. `desktopEntry` is optional
+metadata for the matching KDE application shortcut or external helper.
+`launchMode: "prompt"` shows an OSD reminder when switching to an activity with
+missing apps. Silent automatic launch is intentionally not enabled.
 
 ## Shortcuts
 
@@ -638,7 +637,6 @@ List of all available shortcuts:
 | Move active window right                           | <kbd>Meta</kbd> + <kbd>Right</kbd>                                  |
 | Snap all windows                                   | <kbd>Meta</kbd> + <kbd>Space</kbd>                                  |
 | Snap active window                                 | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>Space</kbd>               |
-| Launch current activity profile                    | Unbound                                                             |
 
 *To change the default bindings, go to `System Settings / Shortcuts` and search for Magnetile*
 

--- a/README.md
+++ b/README.md
@@ -581,6 +581,40 @@ activity. Magnetile restores those remembered placements when switching
 activities, but it does not launch activity-specific apps or persist this
 runtime placement state across KWin restarts.
 
+#### Activity Launcher Profiles
+
+Activity profiles can list apps that belong to a KDE Activity. The first
+launcher implementation is intentionally user-visible: assign a shortcut to
+**Magnetile: Launch current activity profile**, and Magnetile opens KRunner for
+the first missing app in the current profile. When a matching window appears,
+Magnetile snaps it to the configured zone.
+
+Profiles are keyed by KDE Activity id:
+
+```json
+{
+  "activities": {
+    "ee8f04ee-0bb1-486f-89fd-cf31a2b31fbb": {
+      "launchMode": "manual",
+      "apps": [
+        {
+          "name": "Browser",
+          "command": "firefox",
+          "class": "firefox",
+          "zone": 1
+        }
+      ]
+    }
+  }
+}
+```
+
+`zone` is one-based for readability. `command` is sent to KRunner; `class`
+is the KWin window class used to detect existing windows and snap newly opened
+windows. `launchMode: "prompt"` shows an OSD reminder when switching to an
+activity with missing apps. Silent automatic launch is intentionally not enabled
+until Magnetile has a reliable Plasma 6 launch backend.
+
 ## Shortcuts
 
 List of all available shortcuts:
@@ -604,6 +638,7 @@ List of all available shortcuts:
 | Move active window right                           | <kbd>Meta</kbd> + <kbd>Right</kbd>                                  |
 | Snap all windows                                   | <kbd>Meta</kbd> + <kbd>Space</kbd>                                  |
 | Snap active window                                 | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>Space</kbd>               |
+| Launch current activity profile                    | Unbound                                                             |
 
 *To change the default bindings, go to `System Settings / Shortcuts` and search for Magnetile*
 

--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ Profiles are keyed by KDE Activity id:
       "apps": [
         {
           "name": "Browser",
-          "desktopEntry": "firefox.desktop",
+          "desktopEntry": "firefox",
           "class": "firefox",
           "zone": 1
         }
@@ -608,11 +608,12 @@ Profiles are keyed by KDE Activity id:
 }
 ```
 
-`zone` is one-based for readability. `desktopEntry` is opened through the
-system application launcher; `class` is the KWin window class used to detect
-existing windows and snap newly opened windows. `launchMode: "prompt"` shows an
-OSD reminder when switching to an activity with missing apps. Silent automatic
-launch is intentionally not enabled yet.
+`zone` is one-based for readability. `desktopEntry` is the application id used
+by the system launcher, usually the desktop file basename without `.desktop`
+such as `firefox` or `org.kde.kate`; `class` is the KWin window class used to
+detect existing windows and snap newly opened windows. `launchMode: "prompt"`
+shows an OSD reminder when switching to an activity with missing apps. Silent
+automatic launch is intentionally not enabled yet.
 
 ## Shortcuts
 

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -25,8 +25,17 @@ Behavior confirmed by user:
 
 One bug remains to investigate later:
 
-- A window on the side monitor using the `Horizontal Split` layout can move to
-  the top zone after switching activities.
+- A window on the side monitor using the `Horizontal Split` layout could move
+  to the top zone after switching activities.
+- Mitigation added on `issue-12-activity-launcher`: activity-scoped placement
+  save/restore now requires the window's actual KWin output (`client.output` or
+  `client.screen`) and no longer falls back to `Workspace.activeScreen`. This
+  avoids restoring a side-monitor placement against the wrong output while KWin
+  is swapping activities.
+- Verified after reload/restart that KWin loads the script without Magnetile
+  `RangeError`, `ReferenceError`, or `TypeError`. Programmatic activity switch
+  from Default to Activity A and back to Default completed with no filtered KWin
+  errors.
 
 ## Launcher Work Current State
 
@@ -59,11 +68,39 @@ Observed failure:
 
 Conclusion so far:
 
-- Launching apps directly from inside the KWin script is probably the wrong
-  boundary on this Plasma 6 setup.
-- Magnetile should likely own activity profile config and placement detection,
-  while actual app launch should be handled by KDE app shortcuts or a small
-  external helper.
+- Launching apps directly from inside the KWin script is the wrong boundary on
+  this Plasma 6 setup.
+- Magnetile now owns activity profile config and placement detection, while
+  actual app launch is delegated to KDE app shortcuts or a small external helper.
+- The manual Magnetile launcher shortcut registration was removed. Even after
+  removing `Qt.openUrlExternally`, invoking that KWin shortcut still caused
+  `RangeError: Maximum call stack size exceeded`.
+
+External shortcut test result:
+
+- Invoking KDE's Ghostty `_launch` global shortcut through KGlobalAccel started
+  Ghostty via systemd at `2026-05-23T19:17:27-04:00`.
+- No Magnetile `RangeError`, `ReferenceError`, or `TypeError` appeared in KWin
+  logs for that launch.
+- Re-tested after removing the Magnetile launcher shortcut and restarting KWin
+  at `2026-05-23T19:24:15-04:00`; Ghostty again launched externally and KWin
+  logs stayed free of Magnetile JS errors.
+- Ghostty exited quickly on this machine, so the snap could not be visually
+  confirmed from that run. The Magnetile placement path still watches
+  `windowAdded` and matches class `com.mitchellh.ghostty` to zone 2.
+- User later confirmed Ghostty stayed up in zone 2.
+
+## Deferred Work
+
+- Capture/editor and auto-learn profile experiments were abandoned for this
+  release.
+- KWin scripting did not expose `KWin.writeConfig` on this setup, so Magnetile
+  cannot persist learned activity profile rules from inside the script.
+- App launching from inside the KWin script remains out of scope because every
+  attempted backend caused `RangeError: Maximum call stack size exceeded`.
+- If automatic profile capture or profile launching is revisited later, use an
+  external helper/writer boundary instead of direct KWin-side persistence or app
+  launch APIs.
 
 ## Local Test Config
 
@@ -94,7 +131,8 @@ Current `activityProfilesJson` test config in `kwinrc`:
 
 Current shortcut test setup:
 
-- `Ctrl+Alt+L` was removed from `Magnetile: Launch current activity profile`.
+- `Ctrl+Alt+L` was removed from the deleted
+  `Magnetile: Launch current activity profile` action.
 - `Ctrl+Alt+L` was bound to KDE's `Ghostty` application launch action:
   `['com.mitchellh.ghostty.desktop', '_launch', 'Ghostty', 'Ghostty']`.
 
@@ -127,7 +165,6 @@ qdbus6 --literal org.kde.ActivityManager /ActivityManager/Activities ListActivit
 Check launcher test bindings:
 
 ```sh
-gdbus call --session --dest org.kde.kglobalaccel --object-path /kglobalaccel --method org.kde.KGlobalAccel.shortcut "['kwin','Magnetile: Launch current activity profile','KWin','Magnetile: Launch current activity profile']"
 gdbus call --session --dest org.kde.kglobalaccel --object-path /kglobalaccel --method org.kde.KGlobalAccel.shortcut "['com.mitchellh.ghostty.desktop','_launch','Ghostty','Ghostty']"
 ```
 
@@ -147,18 +184,15 @@ tools/reload-clean.sh --restart
 
 1. Do not keep trying more direct launch APIs from KWin until there is a clear
    reason. It has repeatedly caused stack overflow.
-2. Test whether the current external-app-shortcut approach works:
+2. Manually verify the current external-app-shortcut approach with a persistent
+   app window:
    - close Ghostty,
    - press `Ctrl+Alt+L`,
    - verify Ghostty opens,
    - verify Magnetile snaps it to zone 2.
-3. If external-app-shortcut launch plus Magnetile placement works, refocus the
-   feature as:
-   - activity profiles define expected apps and zones,
-   - Magnetile places matching windows,
-   - launching is delegated to KDE shortcuts or an optional helper.
-4. If a true "launch current profile" command is still desired, implement a
+3. If a true "launch current profile" command is still desired, implement a
    small external helper/service and have Magnetile call only that helper, or
    document a KDE shortcut-based setup.
-5. After launcher direction is settled, investigate the side-monitor
-   `Horizontal Split` activity-switch placement bug.
+4. Manually re-test the side-monitor `Horizontal Split` activity-switch case
+   with a real window on the portrait output to confirm the actual-output
+   placement restore fix.

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,0 +1,164 @@
+# Session Handoff
+
+## Branches and PRs
+
+- Current branch: `issue-12-activity-launcher`
+- Launcher draft PR: https://github.com/jcearnal/magnetile/pull/13
+- Launcher issue: https://github.com/jcearnal/magnetile/issues/12
+- Base activity branch: `issue-10-activity-layouts`
+- Activity draft PR: https://github.com/jcearnal/magnetile/pull/11
+- Activity issue: https://github.com/jcearnal/magnetile/issues/10
+
+## Known Good Activity Work
+
+The activity layout/placement feature is working locally and is split into
+revertable commits:
+
+- `5b75a5e` - Add activity-scoped layout tracking.
+- `7ec8398` - Restore placements per activity.
+
+Behavior confirmed by user:
+
+- `Track active layout per activity` works.
+- Existing/shared windows can restore different runtime placements per KDE
+  Activity.
+
+One bug remains to investigate later:
+
+- A window on the side monitor using the `Horizontal Split` layout can move to
+  the top zone after switching activities.
+
+## Launcher Work Current State
+
+Current launcher branch commits:
+
+- `5600373` - Add manual activity launcher profiles.
+- `fec5be6` - Use basic DBusCall for KRunner launcher.
+- `5536b4f` - Avoid nested DBus calls during profile launch.
+- `ddf7513` - Use dedicated KRunner DBus call.
+- `f7186d6` - Use KWin DBus API for KRunner query.
+- `ef1dc31` - Launch profile apps from desktop entries.
+- `d25cb84` - Avoid window scan during manual profile launch.
+- `2128300` - Document launcher desktop entry ids.
+
+Manual app launching from inside the KWin script is not working reliably. Tried
+backends:
+
+- `DBusCall` to `org.kde.krunner /App query`
+- dedicated `DBusCall` object for KRunner
+- `KWin.callDBus(...)` to KRunner
+- `Qt.openUrlExternally("applications:...")`
+
+Observed failure:
+
+- Pressing the Magnetile launcher shortcut reaches the script, but KWin logs
+  `RangeError: Maximum call stack size exceeded`.
+- This persisted after KWin restarts.
+- The stack overflow happened even after removing the missing-window scan and
+  launching the first configured app directly.
+
+Conclusion so far:
+
+- Launching apps directly from inside the KWin script is probably the wrong
+  boundary on this Plasma 6 setup.
+- Magnetile should likely own activity profile config and placement detection,
+  while actual app launch should be handled by KDE app shortcuts or a small
+  external helper.
+
+## Local Test Config
+
+Current activity ids:
+
+- `Activity A`: `57f07b40-68cb-4c02-b70f-3c76a40948aa`
+- `Default`: `ee8f04ee-0bb1-486f-89fd-cf31a2b31fbb`
+
+Current `activityProfilesJson` test config in `kwinrc`:
+
+```json
+{
+  "activities": {
+    "ee8f04ee-0bb1-486f-89fd-cf31a2b31fbb": {
+      "launchMode": "manual",
+      "apps": [
+        {
+          "name": "Ghostty",
+          "desktopEntry": "com.mitchellh.ghostty",
+          "class": "com.mitchellh.ghostty",
+          "zone": 2
+        }
+      ]
+    }
+  }
+}
+```
+
+Current shortcut test setup:
+
+- `Ctrl+Alt+L` was removed from `Magnetile: Launch current activity profile`.
+- `Ctrl+Alt+L` was bound to KDE's `Ghostty` application launch action:
+  `['com.mitchellh.ghostty.desktop', '_launch', 'Ghostty', 'Ghostty']`.
+
+This tests a better practical model:
+
+- KDE/application shortcut launches the app.
+- Magnetile watches `windowAdded` and snaps matching windows based on the
+  activity profile.
+
+## Useful Commands
+
+Check current branch:
+
+```sh
+git status --short --branch
+```
+
+Check relevant KWin logs:
+
+```sh
+journalctl --user -u plasma-kwin_wayland --since "10 minutes ago" | rg "Magnetile|RangeError|ReferenceError|TypeError|Error|Ghostty|Alacritty"
+```
+
+Check activity ids:
+
+```sh
+qdbus6 --literal org.kde.ActivityManager /ActivityManager/Activities ListActivitiesWithInformation
+```
+
+Check launcher test bindings:
+
+```sh
+gdbus call --session --dest org.kde.kglobalaccel --object-path /kglobalaccel --method org.kde.KGlobalAccel.shortcut "['kwin','Magnetile: Launch current activity profile','KWin','Magnetile: Launch current activity profile']"
+gdbus call --session --dest org.kde.kglobalaccel --object-path /kglobalaccel --method org.kde.KGlobalAccel.shortcut "['com.mitchellh.ghostty.desktop','_launch','Ghostty','Ghostty']"
+```
+
+Reload installed script:
+
+```sh
+tools/reload-clean.sh --normal
+```
+
+Restart KWin if callbacks are stale:
+
+```sh
+tools/reload-clean.sh --restart
+```
+
+## Recommended Next Steps
+
+1. Do not keep trying more direct launch APIs from KWin until there is a clear
+   reason. It has repeatedly caused stack overflow.
+2. Test whether the current external-app-shortcut approach works:
+   - close Ghostty,
+   - press `Ctrl+Alt+L`,
+   - verify Ghostty opens,
+   - verify Magnetile snaps it to zone 2.
+3. If external-app-shortcut launch plus Magnetile placement works, refocus the
+   feature as:
+   - activity profiles define expected apps and zones,
+   - Magnetile places matching windows,
+   - launching is delegated to KDE shortcuts or an optional helper.
+4. If a true "launch current profile" command is still desired, implement a
+   small external helper/service and have Magnetile call only that helper, or
+   document a KDE shortcut-based setup.
+5. After launcher direction is settled, investigate the side-monitor
+   `Horizontal Split` activity-switch placement bug.

--- a/aur/.SRCINFO
+++ b/aur/.SRCINFO
@@ -10,6 +10,6 @@ pkgbase = kwin-scripts-magnetile
 	makedepends = zip
 	depends = kwin>=6.4
 	source = magnetile-0.3.0.tar.gz::https://github.com/jcearnal/magnetile/releases/download/v0.3.0/magnetile-0.3.0.tar.gz
-	sha256sums = 60ba6a1d9ccd38d13029167658b6d8fd1242ad57459f4f8622a36773ce40aaef
+	sha256sums = a9969c3584ffad560e7477ad0ec2074879ea8ec662443e899c249932748c31da
 
 pkgname = kwin-scripts-magnetile

--- a/aur/.SRCINFO
+++ b/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = kwin-scripts-magnetile
-	pkgdesc = KWin script for snapping windows into zones with connected tile resizing
-	pkgver = 0.2.2
+	pkgdesc = KWin script for snapping windows into zones with activity-aware layouts
+	pkgver = 0.3.0
 	pkgrel = 1
 	url = https://github.com/jcearnal/magnetile
 	arch = any
@@ -9,7 +9,7 @@ pkgbase = kwin-scripts-magnetile
 	makedepends = make
 	makedepends = zip
 	depends = kwin>=6.4
-	source = kwin-scripts-magnetile-0.2.2.tar.gz::https://github.com/jcearnal/magnetile/archive/refs/tags/v0.2.2.tar.gz
-	sha256sums = 089e8e1097e53fbe195cf6365514eab2007ace9776f772f03e27bb1ebe303fb2
+	source = magnetile-0.3.0.tar.gz::https://github.com/jcearnal/magnetile/releases/download/v0.3.0/magnetile-0.3.0.tar.gz
+	sha256sums = 60ba6a1d9ccd38d13029167658b6d8fd1242ad57459f4f8622a36773ce40aaef
 
 pkgname = kwin-scripts-magnetile

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -10,7 +10,7 @@ license=('GPL-3.0-only')
 depends=('kwin>=6.4')
 makedepends=('kpackage' 'make' 'zip')
 source=("magnetile-${pkgver}.tar.gz::https://github.com/jcearnal/magnetile/releases/download/v${pkgver}/magnetile-${pkgver}.tar.gz")
-sha256sums=('60ba6a1d9ccd38d13029167658b6d8fd1242ad57459f4f8622a36773ce40aaef')
+sha256sums=('a9969c3584ffad560e7477ad0ec2074879ea8ec662443e899c249932748c31da')
 
 build() {
     cd "magnetile-${pkgver}"

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,16 +1,16 @@
 # Maintainer: jcearnal
 
 pkgname=kwin-scripts-magnetile
-pkgver=0.2.3
+pkgver=0.3.0
 pkgrel=1
-pkgdesc="KWin script for snapping windows into zones with connected tile resizing"
+pkgdesc="KWin script for snapping windows into zones with activity-aware layouts"
 arch=('any')
 url="https://github.com/jcearnal/magnetile"
 license=('GPL-3.0-only')
 depends=('kwin>=6.4')
 makedepends=('kpackage' 'make' 'zip')
-source=("${pkgname}-${pkgver}.tar.gz::https://github.com/jcearnal/magnetile/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('bd0898ecd5d972f8f446b9116a94a5e674f52384cea0ff05da2dca2a2a528f24')
+source=("magnetile-${pkgver}.tar.gz::https://github.com/jcearnal/magnetile/releases/download/v${pkgver}/magnetile-${pkgver}.tar.gz")
+sha256sums=('60ba6a1d9ccd38d13029167658b6d8fd1242ad57459f4f8622a36773ce40aaef')
 
 build() {
     cd "magnetile-${pkgver}"

--- a/src/contents/code/core.mjs
+++ b/src/contents/code/core.mjs
@@ -64,6 +64,19 @@ export function loadConfig() {
     monitorLayouts = {};
   }
 
+  let activityProfiles;
+  try {
+    activityProfiles = JSON.parse(KWin.readConfig("activityProfilesJson", "{}"));
+  } catch (e) {
+    activityProfiles = {};
+  }
+  if (!activityProfiles || Array.isArray(activityProfiles) || typeof activityProfiles !== "object") {
+    activityProfiles = {};
+  }
+  if (!activityProfiles.activities || Array.isArray(activityProfiles.activities) || typeof activityProfiles.activities !== "object") {
+    activityProfiles.activities = {};
+  }
+
   config.enableZoneSelector = KWin.readConfig("enableZoneSelector", true);
   config.zoneSelectorTriggerDistance = KWin.readConfig("zoneSelectorTriggerDistance", 1);
   config.enableZoneOverlay = KWin.readConfig("enableZoneOverlay", true);
@@ -77,6 +90,7 @@ export function loadConfig() {
   config.monitorLayouts = monitorLayouts;
   config.trackLayoutPerDesktop = KWin.readConfig("trackLayoutPerDesktop", false);
   config.trackLayoutPerActivity = KWin.readConfig("trackLayoutPerActivity", false);
+  config.activityProfiles = activityProfiles;
   config.showOsdMessages = KWin.readConfig("showOsdMessages", true);
   config.fadeWindowsWhileMoving = KWin.readConfig("fadeWindowsWhileMoving", false);
   config.autoSnapAllNew = KWin.readConfig("autoSnapAllNew", false);

--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -58,6 +58,10 @@
             <default>false</default>
         </entry>
 
+        <entry name="activityProfilesJson" type="String">
+            <default>{}</default>
+        </entry>
+
         <entry name="autoSnapAllNew" type="Bool">
             <default>false</default>
         </entry>

--- a/src/contents/ui/components/Shortcuts.qml
+++ b/src/contents/ui/components/Shortcuts.qml
@@ -21,7 +21,6 @@ Item {
     signal snapAllWindows()
     signal freeActiveWindow()
     signal resetCurrentLayout()
-    signal launchCurrentActivityProfile()
 
     ShortcutHandler {
         name: "Magnetile: Cycle layouts"
@@ -198,15 +197,6 @@ Item {
         sequence: "Ctrl+Alt+R"
         onActivated: {
             resetCurrentLayout();
-        }
-    }
-
-    ShortcutHandler {
-        name: "Magnetile: Launch current activity profile"
-        text: "Magnetile: Launch current activity profile"
-        sequence: ""
-        onActivated: {
-            launchCurrentActivityProfile();
         }
     }
 

--- a/src/contents/ui/components/Shortcuts.qml
+++ b/src/contents/ui/components/Shortcuts.qml
@@ -21,6 +21,7 @@ Item {
     signal snapAllWindows()
     signal freeActiveWindow()
     signal resetCurrentLayout()
+    signal launchCurrentActivityProfile()
 
     ShortcutHandler {
         name: "Magnetile: Cycle layouts"
@@ -197,6 +198,15 @@ Item {
         sequence: "Ctrl+Alt+R"
         onActivated: {
             resetCurrentLayout();
+        }
+    }
+
+    ShortcutHandler {
+        name: "Magnetile: Launch current activity profile"
+        text: "Magnetile: Launch current activity profile"
+        sequence: ""
+        onActivated: {
+            launchCurrentActivityProfile();
         }
     }
 

--- a/src/contents/ui/config.ui
+++ b/src/contents/ui/config.ui
@@ -344,6 +344,43 @@
                       </widget>
                     </item>
                     <item>
+                      <layout class="QFormLayout" name="formLayout_activityProfiles">
+                        <item row="0" column="0">
+                          <widget class="QLabel" name="label_activityProfiles">
+                            <property name="text">
+                              <string>Activity profiles</string>
+                            </property>
+                          </widget>
+                        </item>
+                        <item row="0" column="1">
+                          <widget class="QPlainTextEdit" name="kcfg_activityProfilesJson">
+                            <property name="toolTip">
+                              <string>Optional JSON object mapping KDE Activity ids to launcher profiles.</string>
+                            </property>
+                            <property name="maximumSize">
+                              <size>
+                                <width>16777215</width>
+                                <height>110</height>
+                              </size>
+                            </property>
+                            <property name="plainText">
+                              <string>{}</string>
+                            </property>
+                          </widget>
+                        </item>
+                      </layout>
+                    </item>
+                    <item>
+                      <widget class="QLabel" name="label_activityProfilesExplanation">
+                        <property name="text">
+                          <string>Optional launcher profiles keyed by KDE Activity id. The first implementation opens KRunner for missing apps from the current profile and snaps matching windows when they appear.</string>
+                        </property>
+                        <property name="wordWrap">
+                          <bool>true</bool>
+                        </property>
+                      </widget>
+                    </item>
+                    <item>
                       <widget class="QCheckBox" name="kcfg_autoSnapAllNew">
                         <property name="text">
                           <string>Automatically snap all new windows</string>

--- a/src/contents/ui/config.ui
+++ b/src/contents/ui/config.ui
@@ -355,7 +355,7 @@
                         <item row="0" column="1">
                           <widget class="QPlainTextEdit" name="kcfg_activityProfilesJson">
                             <property name="toolTip">
-                              <string>Optional JSON object mapping KDE Activity ids to launcher profiles.</string>
+                              <string>Optional JSON object mapping KDE Activity ids to app placement profiles.</string>
                             </property>
                             <property name="maximumSize">
                               <size>
@@ -373,7 +373,7 @@
                     <item>
                       <widget class="QLabel" name="label_activityProfilesExplanation">
                         <property name="text">
-                          <string>Optional launcher profiles keyed by KDE Activity id. The first implementation opens KRunner for missing apps from the current profile and snaps matching windows when they appear.</string>
+                          <string>Optional app placement profiles keyed by KDE Activity id. Magnetile snaps matching windows when they appear.</string>
                         </property>
                         <property name="wordWrap">
                           <bool>true</bool>

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -414,6 +414,16 @@ Item {
         return app && app.class !== undefined && app.class !== null ? app.class.toString() : "";
     }
 
+    function appDesktopEntry(app) {
+        if (!app)
+            return "";
+
+        if (app.desktopEntry !== undefined && app.desktopEntry !== null && app.desktopEntry !== "")
+            return app.desktopEntry.toString();
+
+        return "";
+    }
+
     function appLaunchQuery(app) {
         if (!app)
             return "";
@@ -431,7 +441,7 @@ Item {
     }
 
     function appLabel(app) {
-        return app && app.name ? app.name.toString() : (appLaunchQuery(app) || appResourceClass(app) || "app");
+        return app && app.name ? app.name.toString() : (appLaunchQuery(app) || appDesktopEntry(app) || appResourceClass(app) || "app");
     }
 
     function appZoneIndex(app) {
@@ -476,18 +486,14 @@ Item {
         return missing;
     }
 
-    function openKRunnerForApp(app) {
-        const query = appLaunchQuery(app);
-        if (!query)
-            return false;
-
-        try {
-            KWin.callDBus("org.kde.krunner", "/App", "org.kde.krunner.App", "query", query);
-        } catch (error) {
-            console.error("Magnetile: KRunner DBus launch failed: " + error);
+    function openProfileApp(app) {
+        const desktopEntry = appDesktopEntry(app);
+        if (!desktopEntry) {
+            console.error("Magnetile: Activity profile app requires desktopEntry for launching: " + appLabel(app));
             return false;
         }
-        return true;
+
+        return Qt.openUrlExternally("applications:" + desktopEntry);
     }
 
     function launchCurrentActivityProfile() {
@@ -504,7 +510,7 @@ Item {
             return 0;
         }
 
-        const opened = openKRunnerForApp(missing[0]);
+        const opened = openProfileApp(missing[0]);
         return opened ? 1 : 0;
     }
 

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -481,7 +481,7 @@ Item {
         if (!query)
             return false;
 
-        dbusCall.exec("org.kde.krunner", "/App", "query", [query], "org.kde.krunner.App");
+        dbusCall.exec("org.kde.krunner", "/App", "query", [query]);
         Utils.osd("Open " + appLabel(app) + " from KRunner");
         return true;
     }
@@ -3147,10 +3147,9 @@ Item {
     DBusCall {
         id: dbusCall
 
-        function exec(service, path, method, arguments = [], dbusInterface = "") {
+        function exec(service, path, method, arguments = []) {
             this.service = service;
             this.path = path;
-            this.dbusInterface = dbusInterface;
             this.method = method;
             this.arguments = arguments;
             this.call();

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -481,7 +481,7 @@ Item {
         if (!query)
             return false;
 
-        dbusCall.exec("org.kde.krunner", "/App", "query", [query]);
+        krunnerCall.exec("org.kde.krunner", "/App", "org.kde.krunner.App", "query", [query]);
         return true;
     }
 
@@ -3153,6 +3153,23 @@ Item {
 
         Component.onCompleted: {
             Core.registerQMLComponent("dbusCall", dbusCall);
+        }
+    }
+
+    DBusCall {
+        id: krunnerCall
+
+        function exec(service, path, dbusInterface, method, arguments = []) {
+            this.service = service;
+            this.path = path;
+            this.dbusInterface = dbusInterface;
+            this.method = method;
+            this.arguments = arguments;
+            this.call();
+        }
+
+        onFailed: {
+            console.error("Magnetile: KRunner DBus launch failed");
         }
     }
 

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -481,7 +481,12 @@ Item {
         if (!query)
             return false;
 
-        krunnerCall.exec("org.kde.krunner", "/App", "org.kde.krunner.App", "query", [query]);
+        try {
+            KWin.callDBus("org.kde.krunner", "/App", "org.kde.krunner.App", "query", query);
+        } catch (error) {
+            console.error("Magnetile: KRunner DBus launch failed: " + error);
+            return false;
+        }
         return true;
     }
 
@@ -3153,23 +3158,6 @@ Item {
 
         Component.onCompleted: {
             Core.registerQMLComponent("dbusCall", dbusCall);
-        }
-    }
-
-    DBusCall {
-        id: krunnerCall
-
-        function exec(service, path, dbusInterface, method, arguments = []) {
-            this.service = service;
-            this.path = path;
-            this.dbusInterface = dbusInterface;
-            this.method = method;
-            this.arguments = arguments;
-            this.call();
-        }
-
-        onFailed: {
-            console.error("Magnetile: KRunner DBus launch failed");
         }
     }
 

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -53,6 +53,10 @@ Item {
         return client && (client.output || client.screen || Workspace.activeScreen);
     }
 
+    function actualClientOutput(client) {
+        return client && (client.output || client.screen) ? (client.output || client.screen) : null;
+    }
+
     function outputName(screen) {
         return screen && screen.name ? screen.name : "";
     }
@@ -317,7 +321,11 @@ Item {
         if (!config.trackLayoutPerActivity || !client)
             return;
 
-        const key = placementScopeKey(client, clientOutput(client), Workspace.currentDesktop, Workspace.currentActivity);
+        const output = actualClientOutput(client);
+        if (!output)
+            return;
+
+        const key = placementScopeKey(client, output, Workspace.currentDesktop, Workspace.currentActivity);
         const placements = scopedClientPlacements(client);
         const layout = validLayoutIndex(client.layout) ? clampLayoutIndex(client.layout) : currentLayout;
         placements[key] = {
@@ -339,13 +347,17 @@ Item {
     }
 
     function restoreScopedClientPlacement(client, activity) {
-        if (!config.trackLayoutPerActivity || !client || !canMutateWindowGeometry(client))
+        if (!config.trackLayoutPerActivity || !client || disposing || outputsSettling)
             return false;
 
         if (!clientOnActivity(client, activity) || !sameDesktop(client, Workspace.currentDesktop))
             return false;
 
-        const key = placementScopeKey(client, clientOutput(client), Workspace.currentDesktop, activity);
+        const output = actualClientOutput(client);
+        if (!output || !workspaceGeometryReady(output))
+            return false;
+
+        const key = placementScopeKey(client, output, Workspace.currentDesktop, activity);
         const placement = scopedClientPlacements(client)[key];
         if (!placement || !validLayoutIndex(placement.layout))
             return false;
@@ -358,9 +370,9 @@ Item {
         if (placement.freeMove) {
             geometry = rectFromStoredGeometry(placement.geometry);
         } else if (zones.length > 1) {
-            geometry = resizeLogicalGeometry(layout, zones, clientOutput(client));
+            geometry = resizeLogicalGeometry(layout, zones, output);
         } else if (validZoneIndex(layout, zone)) {
-            geometry = targetGeometry(effectiveTargetForZone(layout, zone, clientOutput(client), Workspace.currentDesktop, activity));
+            geometry = targetGeometry(effectiveTargetForZone(layout, zone, output, Workspace.currentDesktop, activity));
         }
 
         if (!geometry)
@@ -486,34 +498,6 @@ Item {
         return missing;
     }
 
-    function openProfileApp(app) {
-        const desktopEntry = appDesktopEntry(app);
-        if (!desktopEntry) {
-            console.error("Magnetile: Activity profile app requires desktopEntry for launching: " + appLabel(app));
-            return false;
-        }
-
-        return Qt.openUrlExternally("applications:" + desktopEntry);
-    }
-
-    function launchCurrentActivityProfile() {
-        const activity = Workspace.currentActivity;
-        const profile = activityProfile(activity);
-        if (!profile) {
-            Utils.osd("No Magnetile activity profile for current activity");
-            return 0;
-        }
-
-        const apps = profileApps(profile);
-        if (apps.length === 0) {
-            Utils.osd("Activity profile has no apps");
-            return 0;
-        }
-
-        const opened = openProfileApp(apps[0]);
-        return opened ? 1 : 0;
-    }
-
     function handleActivityProfilePrompt(activity) {
         const profile = activityProfile(activity);
         if (!profile || profile.launchMode !== "prompt")
@@ -521,7 +505,7 @@ Item {
 
         const missing = missingProfileApps(profile, activity);
         if (missing.length > 0)
-            Utils.osd("Activity profile has " + missing.length + " missing app" + (missing.length === 1 ? "" : "s") + "; use launch shortcut");
+            Utils.osd("Activity profile has " + missing.length + " missing app" + (missing.length === 1 ? "" : "s") + "; use KDE app shortcuts");
     }
 
     function snapProfileWindow(client) {
@@ -3145,9 +3129,6 @@ Item {
         }
         onResetCurrentLayout: {
             resetCurrentLayoutGeometry();
-        }
-        onLaunchCurrentActivityProfile: {
-            launchCurrentActivityProfile();
         }
     }
 

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -256,6 +256,7 @@ Item {
             "oldGeometry": Workspace.activeWindow && Workspace.activeWindow.oldGeometry,
             "activeScreen": activeScreen && activeScreen.name,
             "currentActivity": Workspace.currentActivity,
+            "activityProfiles": config.activityProfiles,
             "currentLayout": currentLayout,
             "screenLayouts": screenLayouts,
             "resize": resizeDebugInfo
@@ -398,6 +399,142 @@ Item {
         }
         Utils.log("Restored " + count + " activity-scoped placements for " + (activity || "<activity>"));
         return count;
+    }
+
+    function activityProfile(activity) {
+        const profiles = config.activityProfiles && config.activityProfiles.activities ? config.activityProfiles.activities : {};
+        return profiles[activity || Workspace.currentActivity] || null;
+    }
+
+    function profileApps(profile) {
+        return profile && isArrayValue(profile.apps) ? profile.apps : [];
+    }
+
+    function appResourceClass(app) {
+        return app && app.class !== undefined && app.class !== null ? app.class.toString() : "";
+    }
+
+    function appLaunchQuery(app) {
+        if (!app)
+            return "";
+
+        if (app.query !== undefined && app.query !== null && app.query !== "")
+            return app.query.toString();
+
+        if (app.command !== undefined && app.command !== null && app.command !== "")
+            return app.command.toString();
+
+        if (app.name !== undefined && app.name !== null)
+            return app.name.toString();
+
+        return "";
+    }
+
+    function appLabel(app) {
+        return app && app.name ? app.name.toString() : (appLaunchQuery(app) || appResourceClass(app) || "app");
+    }
+
+    function appZoneIndex(app) {
+        if (!app || app.zone === undefined || app.zone === null)
+            return -1;
+
+        const zone = Math.round(Number(app.zone)) - 1;
+        return validZoneIndex(currentLayout, zone) ? zone : -1;
+    }
+
+    function clientMatchesProfileApp(client, app, activity) {
+        const resourceClass = appResourceClass(app);
+        if (!resourceClass || clientResourceClass(client) !== resourceClass)
+            return false;
+
+        return clientOnActivity(client, activity || Workspace.currentActivity) && sameDesktop(client, Workspace.currentDesktop);
+    }
+
+    function profileAppExists(app, activity) {
+        for (let i = 0; i < Workspace.stackingOrder.length; i++) {
+            const client = Workspace.stackingOrder[i];
+            if (!client || client.minimized)
+                continue;
+
+            if (clientMatchesProfileApp(client, app, activity))
+                return true;
+        }
+        return false;
+    }
+
+    function missingProfileApps(profile, activity) {
+        const missing = [];
+        const apps = profileApps(profile);
+        for (let i = 0; i < apps.length; i++) {
+            const app = apps[i];
+            if (!appResourceClass(app))
+                continue;
+
+            if (!profileAppExists(app, activity))
+                missing.push(app);
+        }
+        return missing;
+    }
+
+    function openKRunnerForApp(app) {
+        const query = appLaunchQuery(app);
+        if (!query)
+            return false;
+
+        dbusCall.exec("org.kde.krunner", "/App", "query", [query], "org.kde.krunner.App");
+        Utils.osd("Open " + appLabel(app) + " from KRunner");
+        return true;
+    }
+
+    function launchCurrentActivityProfile() {
+        const activity = Workspace.currentActivity;
+        const profile = activityProfile(activity);
+        if (!profile) {
+            Utils.osd("No Magnetile activity profile for current activity");
+            return 0;
+        }
+
+        const missing = missingProfileApps(profile, activity);
+        if (missing.length === 0) {
+            Utils.osd("Activity profile apps are already open");
+            return 0;
+        }
+
+        const opened = openKRunnerForApp(missing[0]);
+        if (opened && missing.length > 1)
+            Utils.osd("Open " + appLabel(missing[0]) + " from KRunner (" + missing.length + " missing)");
+
+        return opened ? 1 : 0;
+    }
+
+    function handleActivityProfilePrompt(activity) {
+        const profile = activityProfile(activity);
+        if (!profile || profile.launchMode !== "prompt")
+            return;
+
+        const missing = missingProfileApps(profile, activity);
+        if (missing.length > 0)
+            Utils.osd("Activity profile has " + missing.length + " missing app" + (missing.length === 1 ? "" : "s") + "; use launch shortcut");
+    }
+
+    function snapProfileWindow(client) {
+        const profile = activityProfile(Workspace.currentActivity);
+        if (!profile || !checkFilter(client))
+            return false;
+
+        const apps = profileApps(profile);
+        for (let i = 0; i < apps.length; i++) {
+            const app = apps[i];
+            if (!clientMatchesProfileApp(client, app, Workspace.currentActivity))
+                continue;
+
+            const zone = appZoneIndex(app);
+            if (zone !== -1) {
+                moveClientToZone(client, zone);
+                return true;
+            }
+        }
+        return false;
     }
 
     function recoverClientZone(client, layout, fallbackToClosest) {
@@ -3002,14 +3139,18 @@ Item {
         onResetCurrentLayout: {
             resetCurrentLayoutGeometry();
         }
+        onLaunchCurrentActivityProfile: {
+            launchCurrentActivityProfile();
+        }
     }
 
     DBusCall {
         id: dbusCall
 
-        function exec(service, path, method, arguments = []) {
+        function exec(service, path, method, arguments = [], dbusInterface = "") {
             this.service = service;
             this.path = path;
+            this.dbusInterface = dbusInterface;
             this.method = method;
             this.arguments = arguments;
             this.call();
@@ -3039,6 +3180,7 @@ Item {
                 currentLayout = getCurrentLayout();
 
             restoreScopedPlacementsForActivity(Workspace.currentActivity);
+            handleActivityProfilePrompt(Workspace.currentActivity);
 
         }
 
@@ -3069,6 +3211,9 @@ Item {
 
             // check if client is in a zone application list
             const resourceClass = clientResourceClass(client);
+            if (snapProfileWindow(client))
+                return;
+
             config.layouts[currentLayout].zones.forEach((zone, zoneIndex) => {
                 if (zone.applications && zone.applications.includes(resourceClass)) {
                     moveClientToZone(client, zoneIndex);

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -504,13 +504,13 @@ Item {
             return 0;
         }
 
-        const missing = missingProfileApps(profile, activity);
-        if (missing.length === 0) {
-            Utils.osd("Activity profile apps are already open");
+        const apps = profileApps(profile);
+        if (apps.length === 0) {
+            Utils.osd("Activity profile has no apps");
             return 0;
         }
 
-        const opened = openProfileApp(missing[0]);
+        const opened = openProfileApp(apps[0]);
         return opened ? 1 : 0;
     }
 

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -482,7 +482,6 @@ Item {
             return false;
 
         dbusCall.exec("org.kde.krunner", "/App", "query", [query]);
-        Utils.osd("Open " + appLabel(app) + " from KRunner");
         return true;
     }
 
@@ -501,9 +500,6 @@ Item {
         }
 
         const opened = openKRunnerForApp(missing[0]);
-        if (opened && missing.length > 1)
-            Utils.osd("Open " + appLabel(missing[0]) + " from KRunner (" + missing.length + " missing)");
-
         return opened ? 1 : 0;
     }
 

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -19,7 +19,7 @@
         "ServiceTypes": [
             "KWin/Script"
         ],
-        "Version": "0.2.3",
+        "Version": "0.3.0",
         "Website": "https://github.com/jcearnal/magnetile.git"
     },
     "X-KDE-ConfigModule": "kwin/effects/configs/kcm_kwin4_genericscripted",


### PR DESCRIPTION
# Session Handoff

## Branches and PRs

- Current branch: `issue-12-activity-launcher`
- Launcher draft PR: https://github.com/jcearnal/magnetile/pull/13
- Launcher issue: https://github.com/jcearnal/magnetile/issues/12
- Base activity branch: `issue-10-activity-layouts`
- Activity draft PR: https://github.com/jcearnal/magnetile/pull/11
- Activity issue: https://github.com/jcearnal/magnetile/issues/10

## Known Good Activity Work

The activity layout/placement feature is working locally and is split into
revertable commits:

- `5b75a5e` - Add activity-scoped layout tracking.
- `7ec8398` - Restore placements per activity.

Behavior confirmed by user:

- `Track active layout per activity` works.
- Existing/shared windows can restore different runtime placements per KDE
  Activity.

One bug remains to investigate later:

- A window on the side monitor using the `Horizontal Split` layout can move to
  the top zone after switching activities.

## Launcher Work Current State

Current launcher branch commits:

- `5600373` - Add manual activity launcher profiles.
- `fec5be6` - Use basic DBusCall for KRunner launcher.
- `5536b4f` - Avoid nested DBus calls during profile launch.
- `ddf7513` - Use dedicated KRunner DBus call.
- `f7186d6` - Use KWin DBus API for KRunner query.
- `ef1dc31` - Launch profile apps from desktop entries.
- `d25cb84` - Avoid window scan during manual profile launch.
- `2128300` - Document launcher desktop entry ids.

Manual app launching from inside the KWin script is not working reliably. Tried
backends:

- `DBusCall` to `org.kde.krunner /App query`
- dedicated `DBusCall` object for KRunner
- `KWin.callDBus(...)` to KRunner
- `Qt.openUrlExternally("applications:...")`

Observed failure:

- Pressing the Magnetile launcher shortcut reaches the script, but KWin logs
  `RangeError: Maximum call stack size exceeded`.
- This persisted after KWin restarts.
- The stack overflow happened even after removing the missing-window scan and
  launching the first configured app directly.

Conclusion so far:

- Launching apps directly from inside the KWin script is probably the wrong
  boundary on this Plasma 6 setup.
- Magnetile should likely own activity profile config and placement detection,
  while actual app launch should be handled by KDE app shortcuts or a small
  external helper.

## Local Test Config

Current activity ids:

- `Activity A`: `57f07b40-68cb-4c02-b70f-3c76a40948aa`
- `Default`: `ee8f04ee-0bb1-486f-89fd-cf31a2b31fbb`

Current `activityProfilesJson` test config in `kwinrc`:

```json
{
  "activities": {
    "ee8f04ee-0bb1-486f-89fd-cf31a2b31fbb": {
      "launchMode": "manual",
      "apps": [
        {
          "name": "Ghostty",
          "desktopEntry": "com.mitchellh.ghostty",
          "class": "com.mitchellh.ghostty",
          "zone": 2
        }
      ]
    }
  }
}
```

Current shortcut test setup:

- `Ctrl+Alt+L` was removed from `Magnetile: Launch current activity profile`.
- `Ctrl+Alt+L` was bound to KDE's `Ghostty` application launch action:
  `['com.mitchellh.ghostty.desktop', '_launch', 'Ghostty', 'Ghostty']`.

This tests a better practical model:

- KDE/application shortcut launches the app.
- Magnetile watches `windowAdded` and snaps matching windows based on the
  activity profile.

## Useful Commands

Check current branch:

```sh
git status --short --branch
```

Check relevant KWin logs:

```sh
journalctl --user -u plasma-kwin_wayland --since "10 minutes ago" | rg "Magnetile|RangeError|ReferenceError|TypeError|Error|Ghostty|Alacritty"
```

Check activity ids:

```sh
qdbus6 --literal org.kde.ActivityManager /ActivityManager/Activities ListActivitiesWithInformation
```

Check launcher test bindings:

```sh
gdbus call --session --dest org.kde.kglobalaccel --object-path /kglobalaccel --method org.kde.KGlobalAccel.shortcut "['kwin','Magnetile: Launch current activity profile','KWin','Magnetile: Launch current activity profile']"
gdbus call --session --dest org.kde.kglobalaccel --object-path /kglobalaccel --method org.kde.KGlobalAccel.shortcut "['com.mitchellh.ghostty.desktop','_launch','Ghostty','Ghostty']"
```

Reload installed script:

```sh
tools/reload-clean.sh --normal
```

Restart KWin if callbacks are stale:

```sh
tools/reload-clean.sh --restart
```

## Recommended Next Steps

1. Do not keep trying more direct launch APIs from KWin until there is a clear
   reason. It has repeatedly caused stack overflow.
2. Test whether the current external-app-shortcut approach works:
   - close Ghostty,
   - press `Ctrl+Alt+L`,
   - verify Ghostty opens,
   - verify Magnetile snaps it to zone 2.
3. If external-app-shortcut launch plus Magnetile placement works, refocus the
   feature as:
   - activity profiles define expected apps and zones,
   - Magnetile places matching windows,
   - launching is delegated to KDE shortcuts or an optional helper.
4. If a true "launch current profile" command is still desired, implement a
   small external helper/service and have Magnetile call only that helper, or
   document a KDE shortcut-based setup.
5. After launcher direction is settled, investigate the side-monitor
   `Horizontal Split` activity-switch placement bug.
